### PR TITLE
Use official bitnami repository for sample app

### DIFF
--- a/use/deploy-apps.adoc
+++ b/use/deploy-apps.adoc
@@ -24,7 +24,7 @@ In this example, we use a Helm repository to deploy a MongoDB chart from Bitnami
 .	Add a Helm repo from Bitnami:
 +
 ----
-helm repo add bitnami https://helm.repo.eng.netapp.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ----
 
 .	Deploy MongoDB:


### PR DESCRIPTION
Use "https://charts.bitnami.com/bitnami" instead of the internal repo; that is established practice across other Astra docs (c.f. https://github.com/NetAppDocs/astra-control-center/blob/main/_include/source-mariadb-deploy-from-helm-chart.adoc)